### PR TITLE
Log outdated samen packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,6 +18,7 @@
     "ink": "^3.2.0",
     "ink-spinner": "^4.0.3",
     "react": "^17.0.2",
+    "semver": "^7.3.7",
     "typescript": "^4.4.4"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
     "@babel/register": "^7.16.9",
     "@tsconfig/recommended": "^1.0.1",
     "@types/react": "^17.0.38",
+    "@types/semver": "^7.3.10",
     "chalk": "^4.1.2",
     "ink-testing-library": "^2.1.0"
   },

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -5,6 +5,6 @@ export default function version() {
   const packageJson = JSON.parse(
     readFileSync(path.resolve(__dirname, `../package.json`)).toString(),
   )
-  console.log(`${packageJson.name}@${packageJson.version}`)
+  console.log(packageJson.version)
   process.exit(0)
 }

--- a/packages/cli/src/components/DevEnv.tsx
+++ b/packages/cli/src/components/DevEnv.tsx
@@ -78,12 +78,14 @@ function DevEnvContent({ command }: { command: SamenCommandDevEnv }) {
       (log) => onAddRow(<Text color="red">{log}</Text>),
     )
 
-    setProjects(newProjects)
-    setLoading(false)
+    return newProjects
   }, [])
 
   useEffect(() => {
-    initialize().catch(fatalError)
+    initialize()
+      .then(setProjects)
+      .catch(fatalError)
+      .finally(() => setLoading(false))
   }, [])
 
   return (

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -5,6 +5,8 @@ import devEnv from "./commands/dev-env"
 import help from "./commands/help"
 import redirect from "./commands/redirect"
 import version from "./commands/version"
+import { fatalError } from "./process"
+import checkAndWarnForVersions from "./utils/checkAndWarnForVersions"
 
 const command = parseSamenCommand(process.argv.slice(2))
 
@@ -14,7 +16,9 @@ switch (command.name) {
     break
 
   case SamenCommandName.Help:
-    help()
+    checkAndWarnForVersions([process.cwd()], console.warn)
+      .then(() => help())
+      .catch(fatalError)
     break
 
   case SamenCommandName.DevEnv:
@@ -22,10 +26,15 @@ switch (command.name) {
     break
 
   case SamenCommandName.Client:
-    redirect("./node_modules/.bin/samen-client", command.argv)
+    checkAndWarnForVersions([process.cwd()], console.warn)
+      .then(() => redirect("./node_modules/.bin/samen-client", command.argv))
+      .catch(fatalError)
+
     break
 
   case SamenCommandName.Server:
-    redirect("./node_modules/.bin/samen-server", command.argv)
+    checkAndWarnForVersions([process.cwd()], console.warn)
+      .then(() => redirect("./node_modules/.bin/samen-server", command.argv))
+      .catch(fatalError)
     break
 }

--- a/packages/cli/src/utils/checkAndWarnForVersions.ts
+++ b/packages/cli/src/utils/checkAndWarnForVersions.ts
@@ -26,10 +26,7 @@ async function getOutdatedGlobal(): Promise<Result> {
 
 async function getOutdatedLocal(cwd: string): Promise<Result> {
   try {
-    await exec(`npm outdated --json ${global ? "--global" : ""}`, {
-      encoding: "utf-8",
-      cwd,
-    })
+    await exec("npm outdated --json", { encoding: "utf-8", cwd })
   } catch (error) {
     if (error instanceof Error && (error as any).stdout) {
       const result = JSON.parse((error as any).stdout) as Record<string, any>

--- a/packages/cli/src/utils/checkAndWarnForVersions.ts
+++ b/packages/cli/src/utils/checkAndWarnForVersions.ts
@@ -1,0 +1,71 @@
+import util from "util"
+import childProcess from "child_process"
+const exec = util.promisify(childProcess.exec)
+
+type Result = [string, { current: string; latest: string; location: string }][]
+
+async function getOutdatedGlobal(): Promise<Result> {
+  try {
+    await exec("npm outdated --json --global", { encoding: "utf-8" })
+  } catch (error) {
+    if (error instanceof Error && (error as any).stdout) {
+      const result = JSON.parse((error as any).stdout) as Record<string, any>
+      return Object.entries(result)
+        .filter(
+          ([packageName]) =>
+            packageName === "samen" || packageName.startsWith("@samen/"),
+        )
+        .map(([packageName, info]) => [
+          packageName,
+          { current: info.current, latest: info.latest, location: "global" },
+        ])
+    }
+  }
+  return []
+}
+
+async function getOutdatedLocal(cwd: string): Promise<Result> {
+  try {
+    await exec(`npm outdated --json ${global ? "--global" : ""}`, {
+      encoding: "utf-8",
+      cwd,
+    })
+  } catch (error) {
+    if (error instanceof Error && (error as any).stdout) {
+      const result = JSON.parse((error as any).stdout) as Record<string, any>
+      return Object.entries(result)
+        .filter(
+          ([packageName]) =>
+            packageName === "samen" || packageName.startsWith("@samen/"),
+        )
+        .map(([packageName, info]) => [
+          packageName,
+          { current: info.current, latest: info.latest, location: cwd },
+        ])
+    }
+  }
+  return []
+}
+
+export default async function checkAndWarnForVersions(
+  cwds: string[],
+  onLog: (log: string) => void,
+): Promise<void> {
+  let outdated: Result = []
+
+  outdated.push(...(await getOutdatedGlobal()))
+
+  for (const cwd of cwds) {
+    outdated.push(...(await getOutdatedLocal(cwd)))
+  }
+
+  if (outdated.length > 0) {
+    onLog("\nSome packages are outdated:\n")
+    for (const [packageName, info] of outdated) {
+      onLog(`  ${packageName}`)
+      onLog(`    Location: ${info.location}`)
+      onLog(`    Current:  ${info.current}`)
+      onLog(`    Latest:   ${info.latest}\n`)
+    }
+  }
+}

--- a/packages/client/src/commands/version.ts
+++ b/packages/client/src/commands/version.ts
@@ -5,6 +5,6 @@ export default function version() {
   const packageJson = JSON.parse(
     readFileSync(path.resolve(__dirname, `../package.json`)).toString(),
   )
-  console.log(`${packageJson.name}@${packageJson.version}`)
+  console.log(packageJson.version)
   process.exit(0)
 }

--- a/packages/server/src/commands/version.ts
+++ b/packages/server/src/commands/version.ts
@@ -5,6 +5,6 @@ export default function version() {
   const packageJson = JSON.parse(
     readFileSync(path.resolve(__dirname, `../package.json`)).toString(),
   )
-  console.log(`${packageJson.name}@${packageJson.version}`)
+  console.log(packageJson.version)
   process.exit(0)
 }


### PR DESCRIPTION
This runs `npm outdated` when starting the cli, and when it turns out any samen-packges are outdated, we're showing it in the CLI:

https://user-images.githubusercontent.com/190501/177311726-94ccd1a2-9a6d-4082-bfbc-ea52337f37d1.mov

Note: We're actually filtering down the results to samen-packages only, which I've temporarily disabled in order to make this recording ☝️ 
