### PR TITLE
Write client to `samen.generated.ts` instead of `samen.ts`

### DIFF
--- a/packages/client/src/utils/writeClientSource.ts
+++ b/packages/client/src/utils/writeClientSource.ts
@@ -15,7 +15,9 @@ export default async function writeClientSource(
   // TODO check where the source lives
   const hasSourceDir = await fileExists(path.join("src"))
   await fs.writeFile(
-    hasSourceDir ? path.join("./src/samen.ts") : path.join("./samen.ts"),
+    hasSourceDir
+      ? path.join("./src/samen.generated.ts")
+      : path.join("./samen.generated.ts"),
     printSourceFile(clientSamenSourceFile),
     {
       encoding: "utf-8",


### PR DESCRIPTION
This generates the client to `samen.generated.ts`, giving the dev the possibility to create a `samen.ts` where the client is initialised.