### PR TITLE
Next gen build command

### DIFF
--- a/packages/cli/src/components/Init.tsx
+++ b/packages/cli/src/components/Init.tsx
@@ -9,14 +9,14 @@ import { useCallback, useEffect, useState } from "react"
 import ActivityIndicator from "./ActivityIndicator"
 import { SamenCommandInit } from "@samen/dev"
 
-const serverSamenFile = `import { createService, createFunction } from '@samen/server'
+const serverSamenFile = `import { createService } from '@samen/server'
 
 async function helloWorld(name: string): Promise<string> {
   return \`Hi there, \${name}!\`
 }
 
 export const helloWorldService = createService({
-  helloWorld: createFunction(helloWorld),
+  helloWorld,
 })
 `
 

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -6,7 +6,8 @@
 	"packages": {
 		"": {
 			"name": "@samen/client",
-			"version": "0.8.0-alpha.6",
+			"version": "0.9.0-rc.6",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"typescript": "^4.4.4"
 			},

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -6,7 +6,8 @@
 	"packages": {
 		"": {
 			"name": "@samen/core",
-			"version": "0.8.0-alpha.6",
+			"version": "0.9.0-rc.6",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"typescript": "^4.4.4"
 			},

--- a/packages/core/src/generateProductionServer.ts
+++ b/packages/core/src/generateProductionServer.ts
@@ -85,8 +85,6 @@ export default function generateProductionServer(
 
   prog.emit()
 
-  console.log(vHost.getFile("samen-production-server.ts"))
-
   const js = vHost.getFile("samen-production-server.js")
 
   if (!js) {

--- a/packages/dev/src/cli/commands.ts
+++ b/packages/dev/src/cli/commands.ts
@@ -11,6 +11,7 @@ export enum ServerCommandName {
   Help = "help",
   Serve = "serve",
   Export = "export",
+  Build = "build",
 }
 
 export interface ServerCommandVersion {
@@ -33,11 +34,17 @@ export interface ServerCommandExport {
   verbose: boolean
 }
 
+export interface ServerCommandBuild {
+  name: ServerCommandName.Build
+  verbose: boolean
+}
+
 export type ServerCommand =
   | ServerCommandVersion
   | ServerCommandHelp
   | ServerCommandServe
   | ServerCommandExport
+  | ServerCommandBuild
 
 // Client
 
@@ -167,6 +174,9 @@ export function parseServerCommand(argv: string[]): ServerCommand {
       return { name, verbose, port }
 
     case ServerCommandName.Export:
+      return { name, verbose }
+
+    case ServerCommandName.Build:
       return { name, verbose }
 
     default:

--- a/packages/dev/src/cli/commands.ts
+++ b/packages/dev/src/cli/commands.ts
@@ -10,7 +10,7 @@ export enum ServerCommandName {
   Version = "version",
   Help = "help",
   Serve = "serve",
-  Build = "build",
+  Export = "export",
 }
 
 export interface ServerCommandVersion {
@@ -28,8 +28,8 @@ export interface ServerCommandServe {
   port: number
 }
 
-export interface ServerCommandBuild {
-  name: ServerCommandName.Build
+export interface ServerCommandExport {
+  name: ServerCommandName.Export
   verbose: boolean
 }
 
@@ -37,7 +37,7 @@ export type ServerCommand =
   | ServerCommandVersion
   | ServerCommandHelp
   | ServerCommandServe
-  | ServerCommandBuild
+  | ServerCommandExport
 
 // Client
 
@@ -166,7 +166,7 @@ export function parseServerCommand(argv: string[]): ServerCommand {
       const port = args["--port"] ?? DEFAULT_SERVER_PORT
       return { name, verbose, port }
 
-    case ServerCommandName.Build:
+    case ServerCommandName.Export:
       return { name, verbose }
 
     default:

--- a/packages/dev/src/cli/help.ts
+++ b/packages/dev/src/cli/help.ts
@@ -76,9 +76,9 @@ export const serverHelpServe = chalk`
   -p, --port    3030  Custom port for the server to be running on
 `
 
-export const serverHelpBuild = chalk`
+export const serverHelpExport = chalk`
 {dim Usage}
-  {yellow {dim $} samen server {bold build} [options]}
+  {yellow {dim $} samen server {bold export} [options]}
 
 {dim Description}
   Takes a samen-file, parses it and generates a manifest and the

--- a/packages/dev/src/cli/help.ts
+++ b/packages/dev/src/cli/help.ts
@@ -89,6 +89,19 @@ export const serverHelpExport = chalk`
   --verbose         Output debug information
 `
 
+export const serverHelpBuild = chalk`
+{dim Usage}
+  {yellow {dim $} samen server {bold build} [options]}
+
+{dim Description}
+  Takes a samen-file, parses it and generates a manifest for it.
+  Assumes a samen-file at {yellow src/samen.ts}.
+
+{dim Options}
+  -h, --help        Output usage information
+  --verbose         Output debug information
+`
+
 export const clientHelp = chalk`
 {dim Usage}
   {yellow {dim $} {bold samen client} [command] [options]}

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { parseServerCommand, ServerCommandName } from "@samen/dev"
+import buildCommand from "./commands/build"
 import exportCommand from "./commands/export"
 import helpCommand from "./commands/help"
 import serveCommand from "./commands/serve"
@@ -24,6 +25,11 @@ switch (command.name) {
 
   case ServerCommandName.Export: {
     exportCommand(command)
+    break
+  }
+
+  case ServerCommandName.Build: {
+    buildCommand(command)
     break
   }
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,29 +1,29 @@
 #!/usr/bin/env node
 
 import { parseServerCommand, ServerCommandName } from "@samen/dev"
-import build from "./commands/build"
-import help from "./commands/help"
-import serve from "./commands/serve"
-import version from "./commands/version"
+import exportCommand from "./commands/export"
+import helpCommand from "./commands/help"
+import serveCommand from "./commands/serve"
+import versionCommand from "./commands/version"
 
 const command = parseServerCommand(process.argv.slice(2))
 
 switch (command.name) {
   case ServerCommandName.Version:
-    version()
+    versionCommand()
     break
 
   case ServerCommandName.Help:
-    help(command)
+    helpCommand(command)
     break
 
   case ServerCommandName.Serve: {
-    serve(command)
+    serveCommand(command)
     break
   }
 
-  case ServerCommandName.Build: {
-    build(command)
+  case ServerCommandName.Export: {
+    exportCommand(command)
     break
   }
 }

--- a/packages/server/src/commands/build.ts
+++ b/packages/server/src/commands/build.ts
@@ -1,3 +1,82 @@
+import {
+  generateAppDeclarationFile,
+  MissingSamenFileError,
+  MissingTSConfigFile,
+  parseSamenApp,
+} from "@samen/core"
 import { ServerCommandBuild } from "@samen/dev"
+import fs from "fs"
+import path from "path"
+import ts, { CompilerOptions } from "typescript"
 
-export default function buildCommand(command: ServerCommandBuild) {}
+export default function buildCommand(command: ServerCommandBuild) {
+  const projectPath = process.cwd()
+
+  const tsConfigFilePath = ts.findConfigFile(
+    projectPath,
+    ts.sys.fileExists,
+    "tsconfig.json",
+  )
+
+  if (!tsConfigFilePath) {
+    throw new MissingTSConfigFile(projectPath)
+  }
+
+  const tsConfig: ts.ParsedCommandLine | undefined =
+    ts.getParsedCommandLineOfConfigFile(
+      tsConfigFilePath,
+      undefined,
+      ts.sys as any,
+    )
+
+  if (!tsConfig) {
+    throw new Error("Can't parse tsconfig.json")
+  }
+
+  const hasES2015 = tsConfig.options.lib?.some((lib: string) =>
+    /(es2015$)|(es2015\.d\.ts)|(es2015.promise$)|(es2015\.promise\.d\.ts)/.test(
+      lib.toLowerCase(),
+    ),
+  )
+  const hasES5 = tsConfig.options.lib?.some((lib: string) =>
+    /(es5$)|(es5\.d\.ts)/.test(lib.toLowerCase()),
+  )
+
+  const compilerOpts: CompilerOptions = {
+    ...tsConfig.options,
+    // declaration: true,
+    // NOTE: we need Promise support in our declaration file. In a normal TS project you would add
+    // the "es2015". Because we're implementing a file system here, sort of, we need to set the file
+    // name more explicitly. (Implementing our own fileExists makes compilation much much faster.)
+    lib: [
+      ...(tsConfig.options.lib ?? []),
+      // support for Promise
+      ...(hasES2015 ? [] : ["lib.es2015.d.ts"]),
+      // support for Pick, Omit, and other TS utilities
+      ...(hasES5 ? [] : ["lib.es5.d.ts"]),
+    ],
+    outDir: path.join(projectPath, ".build"),
+    // target: ts.ScriptTarget.ES5,
+    // module: ts.ModuleKind.CommonJS,
+  }
+
+  const compilerHost = ts.createCompilerHost(compilerOpts)
+
+  const program = ts.createProgram({
+    host: compilerHost,
+    options: compilerOpts,
+    rootNames: [`${projectPath}/src/samen.ts`],
+  })
+
+  const samenSourceFile = program.getSourceFile(`${projectPath}/src/samen.ts`)
+
+  if (!samenSourceFile) {
+    throw new MissingSamenFileError(projectPath)
+  }
+
+  const typeChecker = program.getTypeChecker()
+  const app = parseSamenApp(samenSourceFile, typeChecker)
+  const dts = generateAppDeclarationFile(app, typeChecker)
+  const manifestPath = path.join(projectPath, "samen-manifest.d.ts")
+  fs.writeFileSync(manifestPath, dts)
+}

--- a/packages/server/src/commands/build.ts
+++ b/packages/server/src/commands/build.ts
@@ -1,0 +1,3 @@
+import { ServerCommandBuild } from "@samen/dev"
+
+export default function buildCommand(command: ServerCommandBuild) {}

--- a/packages/server/src/commands/export.ts
+++ b/packages/server/src/commands/export.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import fs from "fs"
-import { ServerCommandBuild } from "@samen/dev"
+import { ServerCommandExport } from "@samen/dev"
 import ts, { CompilerOptions } from "typescript"
 import {
   generateAppDeclarationFile,
@@ -11,7 +11,7 @@ import {
   parseSamenApp,
 } from "@samen/core"
 
-export default function build(command: ServerCommandBuild) {
+export default function exportCommand(command: ServerCommandExport) {
   const projectPath = process.cwd()
 
   const tsConfigFilePath = ts.findConfigFile(
@@ -36,7 +36,9 @@ export default function build(command: ServerCommandBuild) {
   }
 
   const hasES2015 = tsConfig.options.lib?.some((lib: string) =>
-    /(es2015$)|(es2015\.d\.ts)|(es2015.promise$)|(es2015\.promise\.d\.ts)/.test(lib.toLowerCase()),
+    /(es2015$)|(es2015\.d\.ts)|(es2015.promise$)|(es2015\.promise\.d\.ts)/.test(
+      lib.toLowerCase(),
+    ),
   )
   const hasES5 = tsConfig.options.lib?.some((lib: string) =>
     /(es5$)|(es5\.d\.ts)/.test(lib.toLowerCase()),

--- a/packages/server/src/commands/export.ts
+++ b/packages/server/src/commands/export.ts
@@ -70,7 +70,7 @@ export default function exportCommand(command: ServerCommandExport) {
     rootNames: [`${projectPath}/src/samen.ts`],
   })
 
-  const emitResult = program.emit()
+  program.emit()
 
   const samenSourceFile = program.getSourceFile(`${projectPath}/src/samen.ts`)
 
@@ -86,7 +86,7 @@ export default function exportCommand(command: ServerCommandExport) {
 
   const buildPath = path.join(projectPath, ".build")
 
-  const manifestPath = path.join(buildPath, "samen-manifest.d.ts")
+  const manifestPath = path.join(projectPath, "samen-manifest.d.ts")
   fs.writeFileSync(manifestPath, dts)
 
   const samenExecutionJS = path.join(buildPath, "samen-execution.js")
@@ -102,5 +102,9 @@ export default function exportCommand(command: ServerCommandExport) {
   fs.copyFileSync(
     path.join(projectPath, "package-lock.json"),
     path.join(buildPath, "package-lock.json"),
+  )
+  fs.copyFileSync(
+    path.join(projectPath, "samen-manifest.d.ts"),
+    path.join(buildPath, "samen-manifest.d.ts"),
   )
 }

--- a/packages/server/src/commands/help.ts
+++ b/packages/server/src/commands/help.ts
@@ -3,6 +3,7 @@ import {
   ServerCommandName,
   serverHelp,
   serverHelpExport,
+  serverHelpBuild,
   serverHelpServe,
 } from "@samen/dev"
 
@@ -10,6 +11,10 @@ export default function help(command: ServerCommandHelp) {
   switch (command.command) {
     case ServerCommandName.Export:
       console.log(serverHelpExport)
+      break
+
+    case ServerCommandName.Build:
+      console.log(serverHelpBuild)
       break
 
     case ServerCommandName.Serve:

--- a/packages/server/src/commands/help.ts
+++ b/packages/server/src/commands/help.ts
@@ -2,14 +2,14 @@ import {
   ServerCommandHelp,
   ServerCommandName,
   serverHelp,
-  serverHelpBuild,
+  serverHelpExport,
   serverHelpServe,
 } from "@samen/dev"
 
 export default function help(command: ServerCommandHelp) {
   switch (command.command) {
-    case ServerCommandName.Build:
-      console.log(serverHelpBuild)
+    case ServerCommandName.Export:
+      console.log(serverHelpExport)
       break
 
     case ServerCommandName.Serve:


### PR DESCRIPTION
This shuffles around two things:

- The command formally known as `samen-server build` is now called `samen-server export`. This builds a samen-manifest, the RPC's and a production-server (everything you need to run a samen-server standalone) into a `.build` directory.
- There's a new `samen-server build`: This only builds a samen-manifest.